### PR TITLE
fix: add tiny code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ package-lock.json
 node_modules
 example/dist/
 output/
+.vscode/

--- a/example/config/index.html
+++ b/example/config/index.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="bloggista.css">
-    <link rel="stylesheet" href="custom.css">
+    <link rel="stylesheet" href="./custom.css">
     <title>Example</title>
   </head>
 

--- a/example/config/index.html
+++ b/example/config/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="./custom.css">
+    <link rel="stylesheet" href="/custom.css">
     <title>Example</title>
   </head>
 

--- a/src/bloggista/index.ts
+++ b/src/bloggista/index.ts
@@ -15,7 +15,7 @@ interface BloggistaPost {
 }
 
 export class Bloggista {
-  public async findRootFolder(relativePath: string): Promise<Folder> {
+  static async findRootFolder(relativePath: string): Promise<Folder> {
     const baseFolder = new Folder(relativePath);
 
     if (await baseFolder.isRootFolder()) {
@@ -30,16 +30,16 @@ export class Bloggista {
     }
     
     const parentFolder = path.resolve(relativePath, "..")
-    return this.findRootFolder(parentFolder);
+    return Bloggista.findRootFolder(parentFolder);
   }
 
-  public async configFile(): Promise<File> {
-    const bloggistaRoot = await this.findRootFolder('.');
+  static async configFile(): Promise<File> {
+    const bloggistaRoot = await Bloggista.findRootFolder('.');
     return new File(path.resolve(bloggistaRoot.path, 'bloggista.json'));
   }
 
-  public async config(): Promise<BloogistaConfig> {
-    const bloggistaJSON = await this.configFile();
+  static async config(): Promise<BloogistaConfig> {
+    const bloggistaJSON = await Bloggista.configFile();
     const configuration = await bloggistaJSON.read();
     const JSONConfiguration = JSON.parse(configuration);
 

--- a/src/build-command.ts
+++ b/src/build-command.ts
@@ -4,9 +4,8 @@ import { File, Folder } from "./filesystem";
 
 export async function buildCommand(): Promise<void> {
   try {
-    const bloggista = new Bloggista();
     const rootFolder = "./";
-    const bloggistaRootFolder = await bloggista.findRootFolder(rootFolder);
+    const bloggistaRootFolder = await Bloggista.findRootFolder(rootFolder);
     
     await resetDistributionFolder(bloggistaRootFolder);
     
@@ -72,7 +71,7 @@ async function copyCSSFiles(bloggistaFolder: Folder): Promise<void> {
 async function parseLinks(content: string): Promise<string> {
   const regex = /{{link-to:(?<postId>([\w-])*)}}/g;
   const links = content.matchAll(regex);
-  const postsRegistry = (await new Bloggista().config()).posts;
+  const postsRegistry = (await Bloggista.config()).posts;
 
   for (const link of links) {
     const post = postsRegistry[link.groups?.postId!];

--- a/src/create-post-command.ts
+++ b/src/create-post-command.ts
@@ -4,7 +4,7 @@ import { File, Folder } from "./filesystem";
 
 export async function createPostCommand(fileName: string, relativeContentFolder?: string) {
   try {
-    const bloggistaFolder = await (new Bloggista()).findRootFolder('.')
+    const bloggistaFolder = await Bloggista.findRootFolder('.')
     const contentFolder = new Folder(Path.resolve(bloggistaFolder.path, 'content'));
     
     if (relativeContentFolder) await createRecursiveFolders(contentFolder, relativeContentFolder);
@@ -14,8 +14,8 @@ export async function createPostCommand(fileName: string, relativeContentFolder?
     const file = new File(Path.resolve(contentFolder.path, relativeContentFolder || '', `${bloggistaFileName}.html`));
     
     await file.write('<h1>Title</h1>\n\n<p>Start editing here</p>');
-    const bloggistaConfig = await new Bloggista().config();
-    const bloggistaConfigFile = await new Bloggista().configFile();
+    const bloggistaConfig = await Bloggista.config();
+    const bloggistaConfigFile = await Bloggista.configFile();
 
     bloggistaConfig.posts[bloggistaFileName] = {
       id: bloggistaFileName,

--- a/src/filesystem/file.ts
+++ b/src/filesystem/file.ts
@@ -19,8 +19,12 @@ export class File extends FileSystem {
     throw new MissingFileException();
   }
 
+  /**
+    * arguments:
+    * data: string | NodeJS.ArrayBufferView | Iterable<string | NodeJS.ArrayBufferView> |
+    *       AsyncIterable<string | NodeJS.ArrayBufferView> | Stream
+  **/
   public async write(data: Parameters<typeof fs.writeFile>["1"]): Promise<void> {
-    console.log("Been here", this.path);
     await fs.writeFile(this.path, data);
   }
 

--- a/src/filesystem/file.ts
+++ b/src/filesystem/file.ts
@@ -19,7 +19,7 @@ export class File extends FileSystem {
     throw new MissingFileException();
   }
 
-  public async write(data: string): Promise<void> {
+  public async write(data: Parameters<typeof fs.writeFile>["1"]): Promise<void> {
     console.log("Been here", this.path);
     await fs.writeFile(this.path, data);
   }

--- a/src/filesystem/filesystem.ts
+++ b/src/filesystem/filesystem.ts
@@ -2,11 +2,11 @@ import Path from "path";
 import fs from "fs/promises";
 
 export abstract class FileSystem {
-  private _exists: boolean | undefined = undefined;
+  private _exists?: boolean = undefined;
   
   constructor(public readonly path: string) {}
 
-  get name(): string { return Path.basename(this.path); }
+  get name() { return Path.basename(this.path); }
 
   public async exists(): Promise<boolean> {
     if (this._exists !== undefined) return this._exists;

--- a/src/filesystem/folder.ts
+++ b/src/filesystem/folder.ts
@@ -4,7 +4,7 @@ import { File } from "./file";
 import { FileSystem, FileSystemException } from "./filesystem";
 
 export class Folder extends FileSystem {
-  private ROOT_FOLDER: string = '/' as const;
+  private ROOT_FOLDER = '/' as const;
 
   constructor(path: string) {
     super(path);

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -55,8 +55,7 @@ const HTMLTemplate = (name: string) => `<!DOCTYPE html>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/bloggista.css">
-    <link rel="stylesheet" href="/custom.css">
+    <link rel="stylesheet" href="./custom.css">
     <title>${name}</title>
   </head>
 

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -55,7 +55,7 @@ const HTMLTemplate = (name: string) => `<!DOCTYPE html>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="./custom.css">
+    <link rel="stylesheet" href="/custom.css">
     <title>${name}</title>
   </head>
 


### PR DESCRIPTION
This PR adds the following changes:
- fixes the issue of `custom.css` not being correctly referenced
- adds `.vscode` folder to `.gitignore` list
- converts `Bloggista` class's method to static and removes few types that can be inferred by TS itself

Tested locally with [yalc](https://github.com/wclr/yalc), worked fine 😸 